### PR TITLE
Create local copy to avoid potential race condition

### DIFF
--- a/staging/src/k8s.io/client-go/util/workqueue/queue_test.go
+++ b/staging/src/k8s.io/client-go/util/workqueue/queue_test.go
@@ -43,7 +43,7 @@ func TestBasic(t *testing.T) {
 	}
 	for _, test := range tests {
 		// If something is seriously wrong this test will never complete.
-
+		test := test
 		// Start producers
 		const producers = 50
 		producerWG := sync.WaitGroup{}
@@ -106,7 +106,7 @@ func TestAddWhileProcessing(t *testing.T) {
 		},
 	}
 	for _, test := range tests {
-
+		test := test
 		// Start producers
 		const producers = 50
 		producerWG := sync.WaitGroup{}


### PR DESCRIPTION
#### What type of PR is this?

/sig api-machinery
/kind cleanup
/kind flake

#### What this PR does / why we need it:

When running parallel code inside a loop, it's important to avoid referencing the iterator in the loop condition directly, as it can change and we might end up accessing a different thing. To fix this, the best solution is to create a local copy of the struct.

#### Which issue(s) this PR fixes:
Fixes #117805

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

None, this is a test-only change.
